### PR TITLE
Add test to illustrate thread safety issue if used wrongly

### DIFF
--- a/tests/copy_on_write_tests.cpp
+++ b/tests/copy_on_write_tests.cpp
@@ -258,3 +258,16 @@ TEST_CASE("copy_on_write with complex types") {
     CHECK(cow2->value == 42);
     CHECK_FALSE(cow.identity(cow2));
 }
+
+TEST_CASE("copy_on_write long unique write overlaps with sharing") {
+    // This shows how NOT to use copy_on_write.
+    // Write-scopes should never overlap with copying.
+    copy_on_write<int> cow1(42);
+    int& w = cow1.write();
+    CHECK(cow1.unique());
+    const copy_on_write<int> cow2{cow1}; // potentially run on other thread, intending to just grab a read-only copy
+    CHECK_FALSE(cow1.unique());
+    CHECK(*cow2 == 42);
+    w = 100;
+    CHECK(*cow2 == 100); // other thread is surprised to see a new value
+}


### PR DESCRIPTION
I spotted a potential footgun while reviewing an integration of `copy_on_write` into a project which does not have a history of enforcing value-semantics (https://github.com/bitcoin/bitcoin/pull/34424). The footgun shouldn't be firing that often, but I still thought it would be worth documenting with a test.

---

The initial description in copy_on_write.hpp states:

> a thread-safe copy-on-write wrapper for any type that models Regular

If *Regular* implies value-semantics in a way that makes this issue impossible, it might be useful to replicate a description of those constraints in this repository. Or link to a preferred definition.

---

The issue could be mitigated somewhat by changing the `write()`-overloads to be more restrictive (return `void` and `assert(unique())` after mutation):
```C++
    template <class Inplace>
    void write(Inplace inplace) {
        static_assert(std::is_invocable_r_v<void, Inplace, T&>,
                      "Inplace must be invocable with T&");
        if (!unique()) *this = copy_on_write(read());
        inplace(_self->_value);
        assert(unique()); // Catch invalid multi-threading usage.
    }

    template <class Transform, class Inplace>
    void write(Transform transform, Inplace inplace) {
        static_assert(std::is_invocable_r_v<T, Transform, const T&>,
                      "Transform must be invocable with const T&");
        static_assert(std::is_invocable_r_v<void, Inplace, T&>,
                      "Inplace must be invocable with T&");

        if (!unique()) {
            *this = copy_on_write(transform(read()));
        } else {
            inplace(_self->_value);
        }
        assert(unique()); // Catch invalid multi-threading usage.
    }
```
But I understand that would be prohibitive for existing projects.
