### PR TITLE
Write inplace

### DIFF
--- a/include/stlab/copy_on_write.hpp
+++ b/include/stlab/copy_on_write.hpp
@@ -260,7 +260,7 @@ public:
         This will copy the underlying value if necessary so changes to the value do not affect
         other copy_on_write objects sharing the same data.
     */
-    auto write() -> element_type& {
+    [[deprecated]] auto write() -> element_type& {
         if (!unique()) *this = copy_on_write(read());
 
         return _self->_value;

--- a/include/stlab/copy_on_write.hpp
+++ b/include/stlab/copy_on_write.hpp
@@ -310,19 +310,16 @@ public:
 
     /*!
         @brief If the object is not unique, the transform is applied to the underlying value to copy
-       it and a reference to the new value is returned. If the object is unique, the inplace
-       function is called with a reference to the underlying value and a reference to the value is
-       returned.
+       it. If the object is unique, the inplace function is called with a reference to the
+       underlying value.
 
         @param transform A function object that takes a const reference to the underlying value and
         returns a new value.
         @param inplace A function object that takes a reference to the underlying value and modifies
         it in place.
-
-        @return A reference to the underlying value.
     */
     template <class Transform, class Inplace>
-    auto write(Transform transform, Inplace inplace) -> element_type& {
+    void write(Transform transform, Inplace inplace) {
         static_assert(std::is_invocable_r_v<T, Transform, const T&>,
                       "Transform must be invocable with const T&");
         static_assert(std::is_invocable_r_v<void, Inplace, T&>,
@@ -333,8 +330,6 @@ public:
         } else {
             inplace(_self->_value);
         }
-
-        return _self->_value;
     }
 
     /*!

--- a/include/stlab/copy_on_write.hpp
+++ b/include/stlab/copy_on_write.hpp
@@ -267,6 +267,48 @@ public:
     }
 
     /*!
+        @brief Applies `inplace` to the underlying value.
+
+        If the object is not unique, the underlying value is first copied and then `inplace` is
+        invoked on the new, unique value. If the object is already unique, `inplace` is invoked
+        directly.
+
+        @param inplace A function object that takes a reference to the underlying value and modifies
+        it in place.
+    */
+    template <class Inplace>
+    auto write(Inplace inplace)
+        -> std::enable_if_t<std::is_invocable_v<Inplace, T&> &&
+                            std::is_same_v<std::invoke_result_t<Inplace, T&>, void>> {
+        if (!unique()) {
+            *this = copy_on_write(read());
+        }
+
+        inplace(_self->_value);
+    }
+
+    /*!
+        @brief Replaces the underlying value with the result of `transform`.
+
+        If the object is not unique, `transform` is applied to the current value to produce a new
+        value, and the object is rebound to that new value. If the object is already unique, the
+        stored value is updated in place.
+
+        @param transform A function object that takes a const reference to the underlying value and
+        returns a new value.
+    */
+    template <class Transform>
+    auto write(Transform transform)
+        -> std::enable_if_t<std::is_invocable_v<Transform, const T&> &&
+                            std::is_same_v<std::invoke_result_t<Transform, const T&>, T>> {
+        if (!unique()) {
+            *this = copy_on_write(transform(read()));
+        } else {
+            _self->_value = transform(_self->_value);
+        }
+    }
+
+    /*!
         @brief If the object is not unique, the transform is applied to the underlying value to copy
        it and a reference to the new value is returned. If the object is unique, the inplace
        function is called with a reference to the underlying value and a reference to the value is

--- a/tests/copy_on_write_tests.cpp
+++ b/tests/copy_on_write_tests.cpp
@@ -69,7 +69,7 @@ TEST_CASE("copy_on_write copy semantics") {
 
         CHECK(cow1.identity(cow2));
 
-        cow2.write() = 100; // This should trigger copy-on-write
+        cow2.write([](int) { return 100; }); // This should trigger copy-on-write
 
         CHECK(*cow1 == 42);
         CHECK(*cow2 == 100);
@@ -150,8 +150,7 @@ TEST_CASE("copy_on_write access methods") {
     }
 
     SUBCASE("write access when unique") {
-        auto& ref = cow.write();
-        ref = "world";
+        cow.write([](std::string& v) { v = "world"; });
         CHECK(*cow == "world");
         CHECK(cow.unique());
     }
@@ -253,7 +252,7 @@ TEST_CASE("copy_on_write with complex types") {
     copy_on_write<TestStruct> cow2(cow);
     CHECK(cow.identity(cow2));
 
-    cow.write().value = 100;
+    cow.write([](TestStruct& value) { value.value = 100; });
     CHECK(cow->value == 100);
     CHECK(cow2->value == 42);
     CHECK_FALSE(cow.identity(cow2));


### PR DESCRIPTION
* Add single argument overloads for write that take just a transformation or just an action.
* Returning `T&` is easy to use incorrectly and should be removed/deprecated.