### PR TITLE
Remove redundant check (regular implies default constructible)

### DIFF
--- a/include/stlab/copy_on_write.hpp
+++ b/include/stlab/copy_on_write.hpp
@@ -212,9 +212,7 @@ public:
         assert(!_self || ((_self->_count > 0) && "FATAL (sparent) : double delete"));
         if (_self && (_self->_count.fetch_sub(1, std::memory_order_release) == 1)) {
             std::atomic_thread_fence(std::memory_order_acquire);
-            if constexpr (std::is_default_constructible_v<element_type>) {
-                assert(_self != default_model());
-            }
+            assert(_self != default_model());
             delete _self;
         }
     }


### PR DESCRIPTION
I have cherry-picked this commit from a branch where it is enforced that the element type of `copy_on_write` is actually regular. This commit alone has tests failing, because they use `copy_on_write` with a non-regular element type.

@sean-parent, would you prefer enforcement of regular or a weakened requirement?